### PR TITLE
app: Clipboard events API fallback for pastes

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -5,6 +5,9 @@
       "preset": "es6-bundled"
     }
   ],
+  "lint": {
+    "rules": ["polymer-1"]
+  },
   "extraDependencies": [
     "assets/*",
     "src/sketch-app/*.md",

--- a/src/sketch-api/sketch-api.html
+++ b/src/sketch-api/sketch-api.html
@@ -5,25 +5,25 @@
   <template>
     <iron-ajax
         id="getStatsRequest"
-        url="{{protocol}}://{{host}}/sketch/getStats.php?timespan=300"
+        url="https://garyc.me/sketch/getStats.php?timespan=300"
         handle-as="text"
         on-response="_onGetStats"></iron-ajax>
     <iron-ajax
         id="getMaxIDRequest"
-        url="{{protocol}}://{{host}}/sketch/getMaxID.php"
+        url="https://garyc.me/sketch/getMaxID.php"
         handle-as="text"
         on-response="_onSwap"
         on-error="_onError"></iron-ajax>
     <iron-ajax
         id="swapRequest"
-        url="{{protocol}}://{{host}}/sketch/swap.php?v=32"
+        url="https://garyc.me/sketch/swap.php?v=32"
         method="POST"
         handle-as="text"
         on-response="_onSwap"
         on-error="_onError"></iron-ajax>
     <iron-ajax
         id="getRequest"
-        url="{{protocol}}://{{host}}/sketch/get.php"
+        url="https://garyc.me/sketch/get.php"
         handle-as="text"
         on-response="_onGet"
         on-error="_onError"></iron-ajax>
@@ -44,14 +44,6 @@
       // Public properties
 
       properties: {
-        protocol: {
-          type: String,
-          value: "https"
-        },
-        host: {
-          type: String,
-          value: "garyc.me"
-        },
         loading: {
           type: Boolean,
           value: false,

--- a/src/sketch-api/sketch-api.html
+++ b/src/sketch-api/sketch-api.html
@@ -5,25 +5,25 @@
   <template>
     <iron-ajax
         id="getStatsRequest"
-        url="http://{{host}}/sketch/getStats.php?timespan=300"
+        url="{{protocol}}://{{host}}/sketch/getStats.php?timespan=300"
         handle-as="text"
         on-response="_onGetStats"></iron-ajax>
     <iron-ajax
         id="getMaxIDRequest"
-        url="http://{{host}}/sketch/getMaxID.php"
+        url="{{protocol}}://{{host}}/sketch/getMaxID.php"
         handle-as="text"
         on-response="_onSwap"
         on-error="_onError"></iron-ajax>
     <iron-ajax
         id="swapRequest"
-        url="http://{{host}}/sketch/swap.php?v=32"
+        url="{{protocol}}://{{host}}/sketch/swap.php?v=32"
         method="POST"
         handle-as="text"
         on-response="_onSwap"
         on-error="_onError"></iron-ajax>
     <iron-ajax
         id="getRequest"
-        url="http://{{host}}/sketch/get.php"
+        url="{{protocol}}://{{host}}/sketch/get.php"
         handle-as="text"
         on-response="_onGet"
         on-error="_onError"></iron-ajax>
@@ -44,6 +44,10 @@
       // Public properties
 
       properties: {
+        protocol: {
+          type: String,
+          value: "https"
+        },
         host: {
           type: String,
           value: "garyc.me"

--- a/src/sketch-api/sketch-api.html
+++ b/src/sketch-api/sketch-api.html
@@ -5,25 +5,25 @@
   <template>
     <iron-ajax
         id="getStatsRequest"
-        url="https://garyc.me/sketch/getStats.php?timespan=300"
+        url="http://{{host}}/sketch/getStats.php?timespan=300"
         handle-as="text"
         on-response="_onGetStats"></iron-ajax>
     <iron-ajax
         id="getMaxIDRequest"
-        url="https://garyc.me/sketch/getMaxID.php"
+        url="http://{{host}}/sketch/getMaxID.php"
         handle-as="text"
         on-response="_onSwap"
         on-error="_onError"></iron-ajax>
     <iron-ajax
         id="swapRequest"
-        url="https://garyc.me/sketch/swap.php?v=32"
+        url="http://{{host}}/sketch/swap.php?v=32"
         method="POST"
         handle-as="text"
         on-response="_onSwap"
         on-error="_onError"></iron-ajax>
     <iron-ajax
         id="getRequest"
-        url="https://garyc.me/sketch/get.php"
+        url="http://{{host}}/sketch/get.php"
         handle-as="text"
         on-response="_onGet"
         on-error="_onError"></iron-ajax>
@@ -44,6 +44,10 @@
       // Public properties
 
       properties: {
+        host: {
+          type: String,
+          value: "garyc.me"
+        },
         loading: {
           type: Boolean,
           value: false,

--- a/src/sketch-app/keybinds.md
+++ b/src/sketch-app/keybinds.md
@@ -40,7 +40,7 @@
 | `Ctrl`+`S`       | Saves the sketch (as a PNG). |
 | `Ctrl`+`Enter`   | Swaps the sketch. |
 | `Ctrl`+`C`       | Copies sketch data onto the clipboard. |
-| `Ctrl`+`V`       | Pastes sketch data from the clipboard\*. |
-| `Ctrl`+`Alt`+`C` | Copies the sketch onto the clipboard as an image. |
+| `Ctrl`+`V`       | Pastes sketch data from the clipboard. |
+| `Ctrl`+`Alt`+`C` | Copies the sketch onto the clipboard as an image.\* |
 
 \* Doesn't work on Firefox.

--- a/src/sketch-app/sketch-app.html
+++ b/src/sketch-app/sketch-app.html
@@ -1053,7 +1053,7 @@
 
         // Firefox... https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#browser_compatibility
         if(!navigator.clipboard.readText) {
-          window.addEventListener('paste', (e) => {this._pasteProto(e.clipboardData.getData("text"))});
+          window.addEventListener('paste', (e) => {this._pasteText(e.clipboardData.getData("text"))});
         }
 
         // Prevent Chrome from capturing CTRL+S
@@ -1472,17 +1472,17 @@
         }
       },
 
-      _paste: function() {
+      _paste: function(e) {
         if(!navigator.clipboard.readText) {
-          return this._alert('unable to read clipboard');
-        }
-
-        if(this.drawing) {
-          return;
+          if(e.type === "keys-pressed") {
+            return; // handled by fallback
+          } else {
+            return this._alert('unable to read clipboard');
+          }
         }
 
         navigator.clipboard.readText()
-          .then(this._pasteProto.bind(this))
+          .then(text => this._pasteText(text))
           .catch(error => {
             if(error instanceof DOMException) {
               this._alert('no permission to read clipboard');
@@ -1492,7 +1492,11 @@
           });
       },
 
-      _pasteProto: function(text) {
+      _pasteText: function(text) {
+        if(this.drawing) {
+          return;
+        }
+
         text = text.replace(/^[ '"]+|[ '"]+$/g, '');
 
         const pattern = /^[\s0-9a-zA-Z]*$/;

--- a/src/sketch-app/sketch-app.html
+++ b/src/sketch-app/sketch-app.html
@@ -1051,6 +1051,11 @@
         window.addEventListener('freeze', this._saveData.bind(this), {capture: true});
         window.addEventListener("resize", this._hideStats.bind(this));
 
+        // Firefox... https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#browser_compatibility
+        if(!navigator.clipboard.readText) {
+          window.addEventListener('paste', (e) => {this._pasteProto(e.clipboardData.getData("text"))});
+        }
+
         // Prevent Chrome from capturing CTRL+S
         window.addEventListener('keydown', function(event) {
           if((event.ctrlKey || event.metaKey) && !event.altKey && (event.key == 's' || event.key == 'S')) {
@@ -1477,21 +1482,7 @@
         }
 
         navigator.clipboard.readText()
-          .then(text => {
-            text = text.replace(/^[ '"]+|[ '"]+$/g, '');
-
-            const pattern = /^[\s0-9a-zA-Z]*$/;
-            var isValidData = pattern.test(text);
-            if(!isValidData) {
-              return this._alert('invalid clipboard input');
-            };
-
-            this.$.sketch.stop();
-            this.$.sketch.data = text;
-            this.peekID = null;
-            this.sketchDisabled = false;
-            this._alert('pasted from clipboard');
-          })
+          .then(this._pasteProto.bind(this))
           .catch(error => {
             if(error instanceof DOMException) {
               this._alert('no permission to read clipboard');
@@ -1499,6 +1490,22 @@
               throw error;
             }
           });
+      },
+
+      _pasteProto: function(text) {
+        text = text.replace(/^[ '"]+|[ '"]+$/g, '');
+
+        const pattern = /^[\s0-9a-zA-Z]*$/;
+        var isValidData = pattern.test(text);
+        if(!isValidData) {
+          return this._alert('invalid clipboard input');
+        };
+
+        this.$.sketch.stop();
+        this.$.sketch.data = text;
+        this.peekID = null;
+        this.sketchDisabled = false;
+        this._alert('pasted from clipboard');
       },
 
       _changeSize: function(e) {


### PR DESCRIPTION
Async Clipboard API isn't fully supported on Firefox browser ([see MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#browser_compatibility)). This patch implements **reading** clipboard data through Clipboard Event API as fallback in that scenario.